### PR TITLE
Add Project and Room entities with UUID exposed IDs

### DIFF
--- a/src/main/java/com/lowes/controller/RoomController.java
+++ b/src/main/java/com/lowes/controller/RoomController.java
@@ -1,0 +1,49 @@
+package com.lowes.controller;
+
+import com.lowes.dto.request.RoomRequestDTO;
+import com.lowes.dto.response.RoomResponse;
+import com.lowes.entity.Room;
+import com.lowes.mapper.RoomMapper;
+import com.lowes.service.RoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/rooms")
+@RequiredArgsConstructor
+public class RoomController {
+
+    private final RoomService roomService;
+
+    @PostMapping
+    public RoomResponse createRoom(@RequestBody RoomRequestDTO dto) {
+        return RoomMapper.toDTO(roomService.createRoom(dto));
+    }
+
+    @PutMapping("/{exposedId}")
+    public RoomResponse updateRoom(
+            @PathVariable UUID exposedId,
+            @RequestBody RoomRequestDTO dto
+    ) {
+        return RoomMapper.toDTO(roomService.updateRoom(exposedId, dto));
+    }
+
+    @GetMapping("/{exposedId}")
+    public RoomResponse getRoom(@PathVariable UUID exposedId) {
+        return RoomMapper.toDTO(roomService.getRoomById(exposedId));
+    }
+
+    @GetMapping("/project/{projectExposedId}")
+    public List<RoomResponse> getProjectRooms(@PathVariable UUID projectExposedId) {
+        return roomService.getRoomsByProject(projectExposedId).stream()
+                .map(RoomMapper::toDTO)
+                .toList();
+    }
+
+    @DeleteMapping("/{exposedId}")
+    public void deleteRoom(@PathVariable UUID exposedId) {
+        roomService.deleteRoom(exposedId);
+    }
+}

--- a/src/main/java/com/lowes/dto/request/ProjectRequestDTO.java
+++ b/src/main/java/com/lowes/dto/request/ProjectRequestDTO.java
@@ -1,0 +1,17 @@
+package com.lowes.dto.request;
+
+import com.lowes.entity.enums.ServiceType;
+import lombok.*;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectRequestDTO {
+    private String name;
+    private ServiceType serviceType;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer estimatedBudget;
+}

--- a/src/main/java/com/lowes/dto/request/RoomRequestDTO.java
+++ b/src/main/java/com/lowes/dto/request/RoomRequestDTO.java
@@ -1,0 +1,15 @@
+package com.lowes.dto.request;
+
+import com.lowes.entity.enums.RenovationType;
+import lombok.*;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoomRequestDTO {
+    private String name;
+    private RenovationType renovationType;
+    private UUID projectExposedId; // Use exposed ID reference
+}

--- a/src/main/java/com/lowes/dto/response/ProjectResponse.java
+++ b/src/main/java/com/lowes/dto/response/ProjectResponse.java
@@ -1,0 +1,20 @@
+package com.lowes.dto.response;
+
+import com.lowes.entity.enums.ServiceType;
+import lombok.Data;
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+public class ProjectResponse {
+    private String exposedId;
+    private String name;
+    private ServiceType serviceType;
+    private Integer estimatedBudget;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String ownerId; // User's exposed ID
+    private String ownerName;
+    private Integer totalCost;
+    private List<RoomResponse> rooms;
+}

--- a/src/main/java/com/lowes/dto/response/RoomResponse.java
+++ b/src/main/java/com/lowes/dto/response/RoomResponse.java
@@ -1,0 +1,13 @@
+package com.lowes.dto.response;
+
+import com.lowes.entity.enums.RenovationType;
+import java.util.List;
+import java.util.UUID;
+
+public record RoomResponse(
+        UUID exposedId,
+        String name,
+        RenovationType renovationType,
+        List<PhaseResponse> phases,
+        Integer totalCost
+) {}

--- a/src/main/java/com/lowes/entity/Project.java
+++ b/src/main/java/com/lowes/entity/Project.java
@@ -1,42 +1,67 @@
 package com.lowes.entity;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.lowes.entity.enums.ServiceType;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDate;
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-@NoArgsConstructor
-@AllArgsConstructor
+@Entity
+@Table(name = "projects")
 @Getter
 @Setter
-@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Project {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // Internal DB ID
 
-    @ManyToOne
-    @JoinColumn(name = "owner_id")
-    private User owner;
+    @Column(nullable = false, unique = true, updatable = false)
+    private UUID exposedId; // Public-facing ID
 
     private String name;
 
-    @OneToMany(mappedBy = "project",cascade = CascadeType.ALL)
-    @JsonManagedReference("project-phase")
-    private List<Phase> phasesList;
+    @Enumerated(EnumType.STRING)
+    private ServiceType serviceType;
 
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer estimatedBudget;
+    
+    @Transient
+    public Integer getTotalCost() {
+        return rooms.stream()
+            .mapToInt(room -> room.getTotalCost() != null ? room.getTotalCost() : 0)
+            .sum();
+    }
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id")
+    private User owner;
 
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Room> rooms = new ArrayList<>();
 
+    @CreationTimestamp
+    private LocalDateTime createdAt;
 
-
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+    
+    @PrePersist
+    public void prePersist() {
+        if (exposedId == null) {
+            exposedId = UUID.randomUUID();
+        }
+    }
 }

--- a/src/main/java/com/lowes/entity/Room.java
+++ b/src/main/java/com/lowes/entity/Room.java
@@ -1,0 +1,62 @@
+package com.lowes.entity;
+
+import com.lowes.entity.enums.RenovationType;
+import jakarta.persistence.*;
+import lombok.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "rooms")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Room {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // Internal DB ID
+
+    @Column(nullable = false, unique = true, updatable = false)
+    private UUID exposedId; // Public-facing ID
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private RenovationType renovationType;
+
+    private Integer totalCost;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Phase> phases = new ArrayList<>();
+
+    @PrePersist
+    public void prePersist() {
+        if (exposedId == null) {
+            exposedId = UUID.randomUUID();
+        }
+    }
+
+    @PreUpdate
+    public void calculateTotalCost() {
+        if (phases == null) {
+            this.totalCost = 0;
+            return;
+        }
+        
+        this.totalCost = phases.stream()
+            .mapToInt(phase -> 
+                (phase.getTotalPhaseMaterialCost() != null ? phase.getTotalPhaseMaterialCost() : 0) +
+                (phase.getVendorCost() != null ? phase.getVendorCost() : 0)
+            )
+            .sum();
+    }
+}

--- a/src/main/java/com/lowes/entity/User.java
+++ b/src/main/java/com/lowes/entity/User.java
@@ -69,4 +69,9 @@ public class User {
     @OneToMany(mappedBy = "reviewer", cascade = CascadeType.ALL)
     private List<VendorReview> vendorReviews;
 
+    public User orElseThrow(Object object) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'orElseThrow'");
+    }
+
 }

--- a/src/main/java/com/lowes/entity/enums/RenovationType.java
+++ b/src/main/java/com/lowes/entity/enums/RenovationType.java
@@ -1,0 +1,12 @@
+package com.lowes.entity.enums;
+
+
+public enum RenovationType {
+    KITCHEN_RENOVATION,
+    BATHROOM_RENOVATION,
+    BEDROOM_RENOVATION,
+    LIVING_ROOM_RENOVATION,
+    WHOLE_HOME,
+    BALCONY_RENOVATION,
+    FULL_RENOVATION
+}

--- a/src/main/java/com/lowes/entity/enums/ServiceType.java
+++ b/src/main/java/com/lowes/entity/enums/ServiceType.java
@@ -1,0 +1,6 @@
+package com.lowes.entity.enums;
+
+public enum ServiceType {
+    WHOLE_HOUSE,
+    ROOM_WISE
+}

--- a/src/main/java/com/lowes/exception/SecurityException.java
+++ b/src/main/java/com/lowes/exception/SecurityException.java
@@ -1,0 +1,7 @@
+package com.lowes.exception;
+
+public class SecurityException extends RuntimeException {
+    public SecurityException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/lowes/mapper/ProjectMapper.java
+++ b/src/main/java/com/lowes/mapper/ProjectMapper.java
@@ -1,0 +1,29 @@
+package com.lowes.mapper;
+
+import com.lowes.dto.response.ProjectResponse;
+import com.lowes.entity.Project;
+
+public class ProjectMapper {
+
+    public static ProjectResponse toDTO(Project project) {
+        ProjectResponse response = new ProjectResponse();
+        response.setExposedId(project.getExposedId().toString());
+        response.setName(project.getName());
+        response.setServiceType(project.getServiceType());
+        response.setEstimatedBudget(project.getEstimatedBudget());
+        response.setTotalCost(project.getTotalCost());
+        response.setStartDate(project.getStartDate());
+        response.setEndDate(project.getEndDate());
+        
+        if (project.getOwner() != null) {
+            response.setOwnerId(project.getOwner().getExposedId().toString());
+            response.setOwnerName(project.getOwner().getName());
+        }
+        
+        if (project.getRooms() != null) {
+            response.setRooms(project.getRooms().stream().map(RoomMapper::toDTO).toList());
+        }
+        
+        return response;
+    }
+}

--- a/src/main/java/com/lowes/mapper/RoomMapper.java
+++ b/src/main/java/com/lowes/mapper/RoomMapper.java
@@ -1,0 +1,17 @@
+package com.lowes.mapper;
+
+import com.lowes.dto.response.RoomResponse;
+import com.lowes.entity.Room;
+
+public class RoomMapper {
+
+    public static RoomResponse toDTO(Room room) {
+        return new RoomResponse(
+            room.getExposedId(),
+            room.getName(),
+            room.getRenovationType(),
+            room.getPhases().stream().map(PhaseMapper::toDTO).toList(),
+            room.getTotalCost()
+        );
+    }
+}

--- a/src/main/java/com/lowes/repository/ProjectRepository.java
+++ b/src/main/java/com/lowes/repository/ProjectRepository.java
@@ -1,12 +1,22 @@
 package com.lowes.repository;
 
-import com.lowes.entity.Phase;
 import com.lowes.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-public interface ProjectRepository extends JpaRepository<Project, UUID> {
-
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+    List<Project> findByOwnerId(Long ownerId);
+    
+    @Query("SELECT p FROM Project p WHERE p.exposedId = :exposedId")
+    Optional<Project> findByExposedId(@Param("exposedId") UUID exposedId);
+    
+    @Query("SELECT p FROM Project p JOIN p.owner o WHERE p.exposedId = :exposedId AND o.id = :userId")
+    Optional<Project> findByExposedIdAndOwnerId(
+        @Param("exposedId") UUID exposedId,
+        @Param("userId") Long userId
+    );
 }

--- a/src/main/java/com/lowes/repository/RoomRepository.java
+++ b/src/main/java/com/lowes/repository/RoomRepository.java
@@ -1,0 +1,24 @@
+package com.lowes.repository;
+
+import com.lowes.entity.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+    @Query("SELECT r FROM Room r WHERE r.project.exposedId = :projectExposedId")
+    List<Room> findByProjectExposedId(@Param("projectExposedId") UUID projectExposedId);
+    
+    @Query("SELECT r FROM Room r WHERE r.exposedId = :exposedId")
+    Optional<Room> findByExposedId(@Param("exposedId") UUID exposedId);
+    
+    @Query("SELECT r FROM Room r JOIN r.project p JOIN p.owner o " +
+           "WHERE r.exposedId = :exposedId AND o.id = :userId")
+    Optional<Room> findByExposedIdAndOwnerId(
+        @Param("exposedId") UUID exposedId,
+        @Param("userId") Long userId
+    );
+}

--- a/src/main/java/com/lowes/security/ProjectSecurity.java
+++ b/src/main/java/com/lowes/security/ProjectSecurity.java
@@ -1,0 +1,18 @@
+package com.lowes.security;
+
+import com.lowes.entity.Project;
+import com.lowes.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectSecurity {
+
+    private final ProjectRepository projectRepository;
+
+    public boolean isProjectOwner(UUID projectExposedId, Long userId) {
+        return projectRepository.findByExposedIdAndOwnerId(projectExposedId, userId).isPresent();
+    }
+}

--- a/src/main/java/com/lowes/security/RoomSecurity.java
+++ b/src/main/java/com/lowes/security/RoomSecurity.java
@@ -1,0 +1,19 @@
+package com.lowes.security;
+
+import com.lowes.entity.Room;
+import com.lowes.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RoomSecurity {
+
+    private final RoomRepository roomRepository;
+    private final ProjectSecurity projectSecurity;
+
+    public boolean isRoomOwner(UUID roomExposedId, Long userId) {
+        return roomRepository.findByExposedIdAndOwnerId(roomExposedId, userId).isPresent();
+    }
+}

--- a/src/main/java/com/lowes/service/ProjectService.java
+++ b/src/main/java/com/lowes/service/ProjectService.java
@@ -1,21 +1,68 @@
 package com.lowes.service;
 
+import com.lowes.dto.request.ProjectRequestDTO;
 import com.lowes.entity.Project;
+import com.lowes.entity.User;
+import com.lowes.exception.ElementNotFoundException;
 import com.lowes.repository.ProjectRepository;
+import com.lowes.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
-
+import java.util.List;
 import java.util.UUID;
 
 @Service
 public class ProjectService {
 
-    @Autowired
-    ProjectRepository projectRepository;
+    @Autowired private ProjectRepository projectRepository;
+    @Autowired private UserRepository userRepository;
 
-    public Project getProjectById(UUID id) {
-        return projectRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Project not found"));
+    @PreAuthorize("#ownerId == authentication.principal.id")
+    public Project createProject(ProjectRequestDTO dto,  UUID ownerId) {
+    User owner = userRepository.findById(ownerId)
+    .orElseThrow(() -> new ElementNotFoundException("User not found"));
+        Project project = Project.builder()
+                .name(dto.getName())
+                .serviceType(dto.getServiceType())
+                .startDate(dto.getStartDate())
+                .endDate(dto.getEndDate())
+                .estimatedBudget(dto.getEstimatedBudget())
+                .owner(owner)
+                .build();
+        
+        return projectRepository.save(project);
     }
 
+    @PreAuthorize("@projectSecurity.isProjectOwner(#exposedId, authentication.principal.id)")
+    public Project updateProject(UUID exposedId, ProjectRequestDTO dto) {
+        Project project = projectRepository.findByExposedId(exposedId)
+                .orElseThrow(() -> new ElementNotFoundException("Project not found"));
+        
+        project.setName(dto.getName());
+        project.setServiceType(dto.getServiceType());
+        project.setStartDate(dto.getStartDate());
+        project.setEndDate(dto.getEndDate());
+        project.setEstimatedBudget(dto.getEstimatedBudget());
+        
+        return projectRepository.save(project);
+    }
+
+    @PreAuthorize("@projectSecurity.isProjectOwner(#exposedId, authentication.principal.id)")
+    public Project getProjectById(UUID exposedId) {
+        return projectRepository.findByExposedId(exposedId)
+                .orElseThrow(() -> new ElementNotFoundException("Project not found"));
+    }
+
+    @PreAuthorize("#userId == authentication.principal.id")
+    public List<Project> getProjectsByUser(Long userId) {
+        return projectRepository.findByOwnerId(userId);
+    }
+
+    @PreAuthorize("@projectSecurity.isProjectOwner(#exposedId, authentication.principal.id)")
+    public void deleteProject(UUID exposedId) {
+        Project project = projectRepository.findByExposedId(exposedId)
+                .orElseThrow(() -> new ElementNotFoundException("Project not found"));
+        projectRepository.delete(project);
+    }
 }

--- a/src/main/java/com/lowes/service/RoomService.java
+++ b/src/main/java/com/lowes/service/RoomService.java
@@ -1,0 +1,69 @@
+package com.lowes.service;
+
+import com.lowes.dto.request.RoomRequestDTO;
+import com.lowes.entity.Project;
+import com.lowes.entity.Room;
+import com.lowes.exception.ElementNotFoundException;
+// import com.lowes.exception.SecurityException;
+import com.lowes.repository.ProjectRepository;
+import com.lowes.repository.RoomRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+// import org.springframework.security.core.Authentication;
+// import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class RoomService {
+
+    @Autowired private RoomRepository roomRepository;
+    @Autowired private ProjectRepository projectRepository;
+
+    @PreAuthorize("@projectSecurity.isProjectOwner(#dto.projectExposedId, authentication.principal.id)")
+    public Room createRoom(RoomRequestDTO dto) {
+        Project project = projectRepository.findByExposedId(dto.getProjectExposedId())
+                .orElseThrow(() -> new ElementNotFoundException("Project not found"));
+        
+        Room room = Room.builder()
+                .name(dto.getName())
+                .renovationType(dto.getRenovationType())
+                .project(project)
+                .build();
+        
+        return roomRepository.save(room);
+    }
+
+    @PreAuthorize("@roomSecurity.isRoomOwner(#exposedId, authentication.principal.id)")
+    public Room updateRoom(UUID exposedId, RoomRequestDTO dto) {
+        Room room = roomRepository.findByExposedId(exposedId)
+                .orElseThrow(() -> new ElementNotFoundException("Room not found"));
+        
+        room.setName(dto.getName());
+        room.setRenovationType(dto.getRenovationType());
+        
+        return roomRepository.save(room);
+    }
+
+    @PreAuthorize("@roomSecurity.isRoomOwner(#exposedId, authentication.principal.id)")
+    public Room getRoomById(UUID exposedId) {
+        return roomRepository.findByExposedId(exposedId)
+                .orElseThrow(() -> new ElementNotFoundException("Room not found"));
+
+                
+
+    }
+
+    @PreAuthorize("@projectSecurity.isProjectOwner(#projectExposedId, authentication.principal.id)")
+    public List<Room> getRoomsByProject(UUID projectExposedId) {
+        return roomRepository.findByProjectExposedId(projectExposedId);
+    }
+
+    @PreAuthorize("@roomSecurity.isRoomOwner(#exposedId, authentication.principal.id)")
+    public void deleteRoom(UUID exposedId) {
+        Room room = roomRepository.findByExposedId(exposedId)
+                .orElseThrow(() -> new ElementNotFoundException("Room not found"));
+        roomRepository.delete(room);
+    }
+}


### PR DESCRIPTION
feat: Add Project and Room entities with UUID exposed IDs

- Implemented Project entity with auto-generated UUID exportId
- Implemented Room entity with UUID exportId and Project relationship
- Strictly separated internal ID (long) from public APIs
- Used UUIDs for all external references (DTOs/controllers)
- Added @PrePersist for automatic UUID generation
- Room-Project relationship established via exposed IDs